### PR TITLE
Add tests and minor fixes

### DIFF
--- a/connect_test.go
+++ b/connect_test.go
@@ -103,6 +103,7 @@ var MockResponses = map[string]string{
 	URIUserMargins:            "margins.json",
 	URIUserMarginsSegment:     "margins_equity.json",
 	URIGetOrders:              "orders.json",
+	URIModifyOrder:            "order_response.json",
 	URIGetTrades:              "trades.json",
 	URIGetOrderHistory:        "order_info.json",   // "/orders/{order_id}"
 	URIGetOrderTrades:         "order_trades.json", // "/orders/{order_id}/trades"
@@ -153,6 +154,27 @@ func (ts *TestSuite) SetupAPITestSuit() {
 
 		// endpoint := path.Join(ts.KiteConnect.baseURI, route)
 		httpmock.RegisterResponder("GET", base.String(), httpmock.NewBytesResponder(200, resp))
+
+		// for modify endpoints, add a PUT method responder
+		if route == URIGetMFSIPInfo || route == URIModifyOrder || route == URIGetPositions {
+			httpmock.RegisterResponder("PUT", base.String(), httpmock.NewBytesResponder(200, resp))
+		}
+
+		// mock different responses for POST calls
+		if route == URIGetOrderHistory || route == URIGetMFOrders {
+			orderResp, err := ioutil.ReadFile(path.Join(mockBaseDir, "order_response.json"))
+			if err != nil {
+				panic("Error while reading mock response: " + f)
+			}
+			httpmock.RegisterResponder("POST", base.String(), httpmock.NewBytesResponder(200, orderResp))
+		}
+		if route == URIGetMFSIPs {
+			orderResp, err := ioutil.ReadFile(path.Join(mockBaseDir, "mf_order_response.json"))
+			if err != nil {
+				panic("Error while reading mock response: " + f)
+			}
+			httpmock.RegisterResponder("POST", base.String(), httpmock.NewBytesResponder(200, orderResp))
+		}
 	}
 }
 

--- a/mock_responses/mf_holdings.json
+++ b/mock_responses/mf_holdings.json
@@ -2,6 +2,16 @@
   "status": "success",
   "data": [
     {
+      "folio": "123123/123",
+      "fund": "Kotak Select Focus Fund - Direct Plan",
+      "tradingsymbol": "INF174K01LS2",
+      "average_price": 30.729,
+      "last_price": 33.014,
+      "pnl": 594.769,
+      "last_price_date": "2016-11-11",
+      "quantity": 260.337
+    },
+    {
       "folio": "385080203",
       "fund": "DSP BlackRock Money Manager Fund",
       "tradingsymbol": "INF740K01QQ3",

--- a/mock_responses/mf_order_response.json
+++ b/mock_responses/mf_order_response.json
@@ -1,0 +1,7 @@
+{
+    "status": "success",
+    "data": {
+      "order_id": "123457",
+      "sip_id": "123457"
+    }
+  }

--- a/mock_responses/order_response.json
+++ b/mock_responses/order_response.json
@@ -1,0 +1,6 @@
+{
+    "status": "success",
+    "data": {
+      "order_id": "151220000000000"
+    }
+  }

--- a/mutualfunds.go
+++ b/mutualfunds.go
@@ -15,12 +15,13 @@ type MFHolding struct {
 	Tradingsymbol string  `json:"tradingsymbol"`
 	AveragePrice  float64 `json:"average_price"`
 	LastPrice     float64 `json:"last_price"`
+	LastPriceDate string  `json:"last_price_date"`
 	Pnl           float64 `json:"pnl"`
 	Quantity      float64 `json:"quantity"`
 }
 
 // MFHoldings represents a list of mutualfund holdings.
-type MFHoldings []Holding
+type MFHoldings []MFHolding
 
 // MFOrder represents a individual mutualfund order response.
 type MFOrder struct {

--- a/mutualfunds_test.go
+++ b/mutualfunds_test.go
@@ -1,1 +1,121 @@
 package kiteconnect
+
+import (
+	"testing"
+)
+
+func (ts *TestSuite) TestGetMFOrders(t *testing.T) {
+	mfOrders, err := ts.KiteConnect.GetMFOrders()
+	if err != nil {
+		t.Errorf("Error while fetching MF orders. %v", err)
+	}
+	for _, mfOrder := range mfOrders {
+		if mfOrder.OrderID == "" {
+			t.Errorf("Error while fetching order id in MF orders. %v", err)
+		}
+	}
+}
+
+func (ts *TestSuite) TestGetMFOrderInfo(t *testing.T) {
+	orderInfo, err := ts.KiteConnect.GetMFOrderInfo("test")
+	if err != nil {
+		t.Errorf("Error while fetching trades. %v", err)
+	}
+	if orderInfo.OrderID == "" {
+		t.Errorf("Error while fetching order id in MF order info. %v", err)
+	}
+}
+
+func (ts *TestSuite) TestPlaceMFOrder(t *testing.T) {
+	params := MFOrderParams{
+		Tradingsymbol:   "test",
+		TransactionType: "test",
+		Quantity:        100,
+		Amount:          100,
+		Tag:             "test",
+	}
+	orderResponse, err := ts.KiteConnect.PlaceMFOrder(params)
+	if err != nil {
+		t.Errorf("Error while placing MF order. %v", err)
+	}
+	if orderResponse.OrderID == "" {
+		t.Errorf("No order id returned while placing MF order. Error %v", err)
+	}
+}
+
+func (ts *TestSuite) TestGetMFSIPs(t *testing.T) {
+	sips, err := ts.KiteConnect.GetMFSIPs()
+	if err != nil {
+		t.Errorf("Error while fetching MF SIPs. %v", err)
+	}
+	for _, sip := range sips {
+		if sip.ID == "" {
+			t.Errorf("Error while fetching id in MF SIP. %v", err)
+		}
+	}
+}
+
+func (ts *TestSuite) TestGetMFSIPInfo(t *testing.T) {
+	sip, err := ts.KiteConnect.GetMFSIPInfo("test")
+	if err != nil || sip.ID == "" {
+		t.Errorf("Error while fetching MF SIP Info. %v", err)
+	}
+}
+
+func (ts *TestSuite) TestPlaceMFSIP(t *testing.T) {
+	params := MFSIPParams{
+		Tradingsymbol: "test",
+		Amount:        100,
+		Instalments:   100,
+		Frequency:     "4",
+		InstalmentDay: 2,
+		InitialAmount: 2000,
+		Tag:           "test",
+	}
+	sipResponse, err := ts.KiteConnect.PlaceMFSIP(params)
+	if err != nil {
+		t.Errorf("Error while placing MF SIP order. %v", err)
+	}
+	if sipResponse.SIPID == "" {
+		t.Errorf("No SIP id returned while placing MF SIP Order. Error %v", err)
+	}
+}
+
+func (ts *TestSuite) TestModifyMFSIP(t *testing.T) {
+	params := MFSIPModifyParams{
+		Amount:        100,
+		Frequency:     "test",
+		InstalmentDay: 100,
+		Instalments:   100,
+		Status:        "test",
+	}
+	sipResponse, err := ts.KiteConnect.ModifyMFSIP("test", params)
+	if err != nil {
+		t.Errorf("Error while modifying MF SIP order. %v", err)
+	}
+	if sipResponse.SIPID == "" {
+		t.Errorf("No SIP id returned while modifying MF SIP Order. Error %v", err)
+	}
+}
+
+func (ts *TestSuite) TestCancelMFSIP(t *testing.T) {
+	sipResponse, err := ts.KiteConnect.CancelMFSIP("test")
+	if err != nil {
+		t.Errorf("Error while cancelling MF SIP order. %v", err)
+	}
+	if sipResponse.SIPID == "" {
+		t.Errorf("No SIP id returned while cancelling MF SIP Order. Error %v", err)
+	}
+}
+
+func (ts *TestSuite) TestGetMFHoldings(t *testing.T) {
+	holdings, err := ts.KiteConnect.GetMFHoldings()
+	if err != nil {
+		t.Errorf("Error while fetching MF orders. %v", err)
+	}
+	for _, holding := range holdings {
+		if holding.Tradingsymbol == "" {
+			t.Errorf("Error while fetching Tradingsymbol in MF holdings. %v", err)
+		}
+	}
+}

--- a/orders.go
+++ b/orders.go
@@ -160,6 +160,8 @@ func (c *Client) CancelOrder(variety string, orderID string, parentOrderID *stri
 	)
 
 	if parentOrderID != nil {
+		// initialize the params map first
+		params := url.Values{}
 		params.Add("parent_order_id", *parentOrderID)
 	}
 

--- a/orders_test.go
+++ b/orders_test.go
@@ -1,1 +1,129 @@
 package kiteconnect
+
+import (
+	"testing"
+)
+
+func (ts *TestSuite) TestGetOrders(t *testing.T) {
+	orders, err := ts.KiteConnect.GetOrders()
+	if err != nil {
+		t.Errorf("Error while fetching orders. %v", err)
+	}
+	for _, order := range orders {
+		if order.OrderID == "" {
+			t.Errorf("Error while fetching order id in orders. %v", err)
+		}
+	}
+}
+
+func (ts *TestSuite) TestGetTrades(t *testing.T) {
+	trades, err := ts.KiteConnect.GetTrades()
+	if err != nil {
+		t.Errorf("Error while fetching trades. %v", err)
+	}
+	for _, trade := range trades {
+		if trade.TradeID == "" {
+			t.Errorf("Error while fetching trade id in trades. %v", err)
+		}
+	}
+}
+
+func (ts *TestSuite) TestGetOrderHistory(t *testing.T) {
+	orderHistory, err := ts.KiteConnect.GetOrderHistory("test")
+	if err != nil {
+		t.Errorf("Error while fetching trades. %v", err)
+	}
+	for _, order := range orderHistory {
+		if order.OrderID == "" {
+			t.Errorf("Error while fetching order id in order history. %v", err)
+		}
+	}
+}
+
+func (ts *TestSuite) TestGetOrderTrades(t *testing.T) {
+	tradeHistory, err := ts.KiteConnect.GetOrderTrades("test")
+	if err != nil {
+		t.Errorf("Error while fetching trades. %v", err)
+	}
+	for _, trade := range tradeHistory {
+		if trade.TradeID == "" {
+			t.Errorf("Error while fetching trade id in trade history. %v", err)
+		}
+	}
+}
+
+func (ts *TestSuite) TestPlaceOrder(t *testing.T) {
+	params := OrderParams{
+		Exchange:          "test",
+		Tradingsymbol:     "test",
+		Validity:          "test",
+		Product:           "test",
+		OrderType:         "test",
+		TransactionType:   "test",
+		Quantity:          100,
+		DisclosedQuantity: 100,
+		Price:             100,
+		TriggerPrice:      100,
+		Squareoff:         100,
+		Stoploss:          100,
+		TrailingStoploss:  100,
+		Tag:               "test",
+	}
+	orderResponse, err := ts.KiteConnect.PlaceOrder("test", params)
+	if err != nil {
+		t.Errorf("Error while placing order. %v", err)
+	}
+	if orderResponse.OrderID == "" {
+		t.Errorf("No order id returned. Error %v", err)
+	}
+}
+
+func (ts *TestSuite) TestModifyOrder(t *testing.T) {
+	params := OrderParams{
+		Exchange:          "test",
+		Tradingsymbol:     "test",
+		Validity:          "test",
+		Product:           "test",
+		OrderType:         "test",
+		TransactionType:   "test",
+		Quantity:          100,
+		DisclosedQuantity: 100,
+		Price:             100,
+		TriggerPrice:      100,
+		Squareoff:         100,
+		Stoploss:          100,
+		TrailingStoploss:  100,
+		Tag:               "test",
+	}
+	orderResponse, err := ts.KiteConnect.ModifyOrder("test", "test", params)
+	if err != nil {
+		t.Errorf("Error while placing order. %v", err)
+	}
+	if orderResponse.OrderID == "" {
+		t.Errorf("No order id returned. Error %v", err)
+	}
+}
+
+func (ts *TestSuite) TestCancelOrder(t *testing.T) {
+	parentOrderID := "test"
+
+	orderResponse, err := ts.KiteConnect.CancelOrder("test", "test", &parentOrderID)
+	if err != nil {
+		t.Errorf("Error while placing order. %v", err)
+	}
+	if orderResponse.OrderID == "" {
+		t.Errorf("No order id returned. Error %v", err)
+	}
+}
+
+func (ts *TestSuite) TestExitOrder(t *testing.T) {
+	parentOrderID := "test"
+
+	orderResponse, err := ts.KiteConnect.ExitOrder("test", "test", &parentOrderID)
+	if err != nil {
+		t.Errorf("Error while placing order. %v", err)
+	}
+	if orderResponse.OrderID == "" {
+		t.Errorf("No order id returned. Error %v", err)
+	}
+}

--- a/portfolio_test.go
+++ b/portfolio_test.go
@@ -1,1 +1,56 @@
 package kiteconnect
+
+import (
+	"testing"
+)
+
+func (ts *TestSuite) TestGetPositions(t *testing.T) {
+	positions, err := ts.KiteConnect.GetPositions()
+	if err != nil {
+		t.Errorf("Error while fetching positions. %v", err)
+	}
+	if positions.Day == nil {
+		t.Errorf("Error while fetching day positions. %v", err)
+	}
+	if positions.Net == nil {
+		t.Errorf("Error while fetching net positions. %v", err)
+	}
+	for _, position := range positions.Day {
+		if position.Tradingsymbol == "" {
+			t.Errorf("Error while fetching trading symbol in day position. %v", err)
+		}
+	}
+	for _, position := range positions.Net {
+		if position.Tradingsymbol == "" {
+			t.Errorf("Error while fetching tradingsymbol in net position. %v", err)
+		}
+	}
+}
+
+func (ts *TestSuite) TestGetHoldings(t *testing.T) {
+	holdings, err := ts.KiteConnect.GetHoldings()
+	if err != nil {
+		t.Errorf("Error while fetching holdings. %v", err)
+	}
+	for _, holding := range holdings {
+		if holding.Tradingsymbol == "" {
+			t.Errorf("Error while fetching tradingsymbol in holdings. %v", err)
+		}
+	}
+}
+
+func (ts *TestSuite) TestConvertPosition(t *testing.T) {
+	params := ConvertPositionParams{
+		Exchange:        "test",
+		TradingSymbol:   "test",
+		OldProduct:      "test",
+		NewProduct:      "test",
+		PositionType:    "test",
+		TransactionType: "test",
+		Quantity:        "test",
+	}
+	response, err := ts.KiteConnect.ConvertPosition(params)
+	if err != nil || response != true {
+		t.Errorf("Error while converting position. %v", err)
+	}
+}


### PR DESCRIPTION
- Add tests in 
  - `orders_test.go`
  - `mutualfunds_test.go`
  - `portfolio_test.go`

- Fix runtime error in [L63:orders.go](https://github.com/zerodhatech/gokiteconnect/blob/master/orders.go#L163) where the map wasn't initialised.  Traceback: 
`panic: assignment to entry in nil map`

- Fix wrong struct being used for MF Holdings in [L23:mutualfunds.go](https://github.com/zerodhatech/gokiteconnect/blob/master/mutualfunds.go#L23)

- Add `last_price_date` to `MFHolding` struct as it is being sent in the [original](https://kite.trade/docs/connect/v3/mutual-funds/#holdings) response.

- Add additional `POST/PUT` `HTTP` Responders 

- Add more mock responses to cover `POST` endpoint responses.
