### PR TITLE
fix cancel order to use HTTP DELETE method

### DIFF
--- a/orders.go
+++ b/orders.go
@@ -165,7 +165,7 @@ func (c *Client) CancelOrder(variety string, orderID string, parentOrderID *stri
 		params.Add("parent_order_id", *parentOrderID)
 	}
 
-	err := c.doEnvelope(http.MethodPut, fmt.Sprintf(URICancelOrder, variety, orderID), params, nil, &orderResponse)
+	err := c.doEnvelope(http.MethodDelete, fmt.Sprintf(URICancelOrder, variety, orderID), params, nil, &orderResponse)
 	return orderResponse, err
 }
 


### PR DESCRIPTION
As per kite api docs, https://kite.trade/docs/connect/v3/orders/#cancelling-orders , the cancel order must send a DELETE request to cancel an order. This PR updates the http method from PUT to DELETE for the cancel order api.