### PR TITLE
Added TPIN auth error and function to fetch tpin auth request id

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -100,6 +100,7 @@ const (
 	URIGetPositions    string = "/portfolio/positions"
 	URIGetHoldings     string = "/portfolio/holdings"
 	URIConvertPosition string = "/portfolio/positions"
+	URITPINAuthReqID   string = "/portfolio/holdings/authorise"
 
 	// MF endpoints
 	URIGetMFOrders      string = "/mf/orders"

--- a/errors.go
+++ b/errors.go
@@ -17,6 +17,7 @@ const (
 	InputError      = "InputException"
 	DataError       = "DataException"
 	NetworkError    = "NetworkException"
+	TPINAuthError   = "TPINAuthException"
 )
 
 // Error is the error type used for all API errors.
@@ -59,6 +60,8 @@ func NewError(etype string, message string, data interface{}) error {
 		err.Code = http.StatusGatewayTimeout
 	case NetworkError:
 		err.Code = http.StatusServiceUnavailable
+	case TPINAuthError:
+		err.Code = http.StatusPreconditionRequired
 	default:
 		err.Code = http.StatusInternalServerError
 		err.ErrorType = GeneralError
@@ -80,6 +83,8 @@ func GetErrorName(code int) string {
 		err = InputError
 	case http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 		err = NetworkError
+	case http.StatusPreconditionRequired:
+		err = TPINAuthError
 	default:
 		err = GeneralError
 	}

--- a/http.go
+++ b/http.go
@@ -149,6 +149,9 @@ func (h *httpClient) DoEnvelope(method, url string, params url.Values, headers h
 			return NewError(DataError, "Error parsing response.", nil)
 		}
 
+		if resp.Response.StatusCode == http.StatusPreconditionRequired {
+			return NewError(TPINAuthError, e.Message, e.Data)
+		}
 		return NewError(e.ErrorType, e.Message, e.Data)
 	}
 

--- a/portfolio.go
+++ b/portfolio.go
@@ -90,6 +90,11 @@ type ConvertPositionParams struct {
 	Quantity        string `url:"quantity"`
 }
 
+// TPINAuthoriseRequestID represents
+type TPINAuthoriseRequestID struct {
+	RequestID string `json:"request_id"`
+}
+
 // GetHoldings gets a list of holdings.
 func (c *Client) GetHoldings() (Holdings, error) {
 	var holdings Holdings
@@ -102,6 +107,18 @@ func (c *Client) GetPositions() (Positions, error) {
 	var positions Positions
 	err := c.doEnvelope(http.MethodGet, URIGetPositions, nil, nil, &positions)
 	return positions, err
+}
+
+// GetTPINAuthReqID gets requestID to invoke TPIN authorisation page for a given holding type (mf or eq)
+func (c *Client) GetTPINAuthReqID(holdingType string) (TPINAuthoriseRequestID, error) {
+	var (
+		reqID TPINAuthoriseRequestID
+		err   error
+	)
+	params := url.Values{}
+	params["type"] = []string{holdingType}
+	err = c.doEnvelope(http.MethodPost, URITPINAuthReqID, params, nil, &reqID)
+	return reqID, err
 }
 
 // ConvertPosition converts postion's product type.


### PR DESCRIPTION
1. Added an exception `TPINAuthError` and return status code `StatusPreconditionRequired` for calls that gets 428 from Kite
2. Added a function in portfolio scope to fetch TPIN authorisation request id. It takes holding type param that can be mf for Mutual funds. 